### PR TITLE
Fix composer requirement from typo3-ter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"typo3-ter/theme_bootstrap4": "self.version"
 	},
 	"require": {
-		"typo3-ter/dyncss_scss": ">=1.1.0,<2.0.0",
+		"typo3-ter/dyncss-scss": ">=1.1.0,<2.0.0",
 		"typo3-themes/themes-gridelements": ">=7.0.1,<8.7"
 	}
 }


### PR DESCRIPTION
Since all composer packages with vendor typo3-ter use "-" instead of "_" the required packed couldn't be resolved. Changed it to "dyncss-scss".